### PR TITLE
fix: docker-compose.yml의 docker-network 수정

### DIFF
--- a/docker/docker-compose.blue.yml
+++ b/docker/docker-compose.blue.yml
@@ -26,4 +26,4 @@ services:
 networks:
   default:
     external: true
-    name: blue-network
+    name: app-network

--- a/docker/docker-compose.green.yml
+++ b/docker/docker-compose.green.yml
@@ -21,5 +21,4 @@ services:
 networks:
   default:
     external: true
-    name: green-network
-
+    name: app-network


### PR DESCRIPTION
docker-compose-{blue/green}.yml의 docker network를 app-network로 통일