### PR TITLE
fix: AfterInstall 단계에서 현재 배포 파일 삭제 제외 (#302)

### DIFF
--- a/scripts/cleanup-after-install.sh
+++ b/scripts/cleanup-after-install.sh
@@ -2,8 +2,19 @@
 
 echo "[INFO] AfterInstall: d-* 캐시 정리 시작"
 
-# d- 접두어로 시작하는 캐시 디렉토리만 정리
-sudo rm -rf /opt/codedeploy-agent/deployment-root/*/d-*
+# 현재 실행 중인 배포 디렉토리 경로 얻기
+CURRENT_DEPLOY_DIR=$(dirname "$(readlink -f "$0")")   # cleanup-after-install.sh 경로 기반
+CURRENT_D_ID=$(echo "$CURRENT_DEPLOY_DIR" | grep -o 'd-[^/]*')
+
+# 삭제할 목록에서 현재 d-ID는 제외
+for d in /opt/codedeploy-agent/deployment-root/*/d-*; do
+  if [[ "$d" != *"$CURRENT_D_ID"* ]]; then
+    echo "[INFO] 삭제 대상: $d"
+    rm -rf "$d"
+  else
+    echo "[INFO] 현재 배포 디렉토리 $d 는 건너뜀"
+  fi
+done
 
 echo "[INFO] AfterInstall: 정리 완료"
 exit 0


### PR DESCRIPTION
## #️⃣ Issue Number
#302 
<!--- ex) close #이슈번호 -->

## 📝 요약(Summary)
- AfterInstall 단계에서 현재 배포 파일 삭제 제외
- 현재 배포 파일도 삭제해서 ApplicationStart가 실행이 안됨
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 📸스크린샷 (선택)
