### PR TITLE
fix: AfterInstall 권한 root로 변경 (#302)

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -25,4 +25,4 @@ hooks:
   AfterInstall:
     - location: cleanup-after-install.sh
       timeout: 60
-      runas: ubuntu
+      runas: root


### PR DESCRIPTION
## #️⃣ Issue Number
#302 
<!--- ex) close #이슈번호 -->

## 📝 요약(Summary)
- AfterInstall 권한 root로 변경
- 이전 파일이 권한 문제로 삭제가 안됨
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 📸스크린샷 (선택)
