### PR TITLE
fix: 주문 상태 변경(#344)

### DIFF
--- a/src/main/java/PodoeMarket/podoemarket/admin/controller/AdminController.java
+++ b/src/main/java/PodoeMarket/podoemarket/admin/controller/AdminController.java
@@ -145,12 +145,11 @@ public class AdminController {
         try {
             adminService.checkAuth(userInfo);
 
-            OrdersEntity order = adminService.orders(orderId);
+            final OrdersEntity order = adminService.orders(orderId);
 
             if (dto.getOrderStatus() != null) {
                 if (dto.getOrderStatus() == OrderStatus.REJECT)
-                    mailSendService.joinCancelEmail(userInfo.getEmail(), order.getOrderItem().getFirst().getProduct().getTitle());
-
+                    mailSendService.joinCancelEmail(order.getUser().getEmail(), order.getOrderItem().getFirst().getProduct().getTitle());
                 order.setOrderStatus(dto.getOrderStatus());
             }
 

--- a/src/main/java/PodoeMarket/podoemarket/admin/service/AdminService.java
+++ b/src/main/java/PodoeMarket/podoemarket/admin/service/AdminService.java
@@ -226,7 +226,7 @@ public class AdminService {
 
     public OrdersEntity orders(final Long orderId) {
         try {
-            return orderRepo.findById(orderId).orElse(null);
+            return orderRepo.findOrderById(orderId);
         } catch (Exception e) {
             throw new RuntimeException("주문 조회 실패", e);
         }

--- a/src/main/java/PodoeMarket/podoemarket/common/repository/OrderRepository.java
+++ b/src/main/java/PodoeMarket/podoemarket/common/repository/OrderRepository.java
@@ -5,8 +5,18 @@ import PodoeMarket.podoemarket.common.entity.type.OrderStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends JpaRepository<OrdersEntity, Long> {
     Long countAllByOrderStatus(OrderStatus orderStatus);
+
     Page<OrdersEntity> findAllByOrderStatus(OrderStatus orderStatus, Pageable pageable);
+
+    @Query("SELECT o FROM OrdersEntity o " +
+            "JOIN FETCH o.user " +
+            "JOIN FETCH o.orderItem oi " +
+            "JOIN FETCH oi.product " +
+            "WHERE o.id = :orderId")
+    OrdersEntity findOrderById(@Param("orderId") Long orderId);
 }


### PR DESCRIPTION
## #️⃣ Issue Number
close #344 

## 📝 요약(Summary)
fetch = FetchType.LAZY의 지연 로딩 설정으로 order 엔티티에서 user 정보를 가져오는 것을 실패함. JPA 기본 메서드가 아닌 JPQL로 fetch join을 실행하여 필요한 연관 관계만 선택적으로 패치함

## 📸스크린샷 (선택)
